### PR TITLE
Change the getIssuers method

### DIFF
--- a/src/Message/Response/FetchIssuers.php
+++ b/src/Message/Response/FetchIssuers.php
@@ -23,14 +23,11 @@ class FetchIssuers extends AbstractResponse
     public function getIssuers() {
         if (isset($this->data['Directory'])) {
             $issuers = array();
-            foreach ($this->data['Directory']['Country'] as $country) {
-                foreach ($country['Issuer'] as $issuer) {
-                    $id = (string) $issuer->issuerID;
-                    $issuers[(string)$country->countryNames][$id] = (string) $issuer->issuerName;
-                }
+            foreach ($this->data['Directory']['Country']['Issuer'] as $issuer) {
+                $id = (string) $issuer['issuerID'];
+                $issuers[$id] = (string) $issuer['issuerName'];
             }
             return $issuers;
         }
     }
-
 }


### PR DESCRIPTION
The getIssuers method was created, assuming we should extract data from an object.

This is what I received:
`Array
(
    [@attributes] => Array
        (
            [version] => 3.3.1
        )

    [createDateTimestamp] => 20xx-0x-xxT00:00:00.000Z
    [Acquirer] => Array
        (
            [acquirerID] => xxxx
        )

    [Directory] => Array
        (
            [directoryDateTimestamp] => 20xx-0x-xxT00:00:00.000Z
            [Country] => Array
                (
                    [countryNames] => Nederland
                    [Issuer] => Array
                        (
                            [0] => Array
                                (
                                    [issuerID] => ABNANL2A
                                    [issuerName] => ABN AMRO
                                )

                            [1] => Array
                                (
                                    [issuerID] => ASNBNL21
                                    [issuerName] => ASN Bank
                                )
                            etc.  `

So I've changed the method the handle it according an array and return a simple array with issuerID as key and issuerName as value.