### PR TITLE
ABN AMRO support

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -24,7 +24,7 @@ class Gateway extends AbstractGateway
     public function getDefaultParameters()
     {
         return [
-            'acquirer'             => ['', 'simulator', 'ing', 'rabobank'],
+            'acquirer'             => ['', 'simulator', 'ing', 'rabobank', 'abn'],
             'merchantId'           => '',
             'publicKeyPath'        => '',
             'privateKeyPath'       => '',

--- a/src/Message/Request/AbstractRequest.php
+++ b/src/Message/Request/AbstractRequest.php
@@ -205,6 +205,9 @@ abstract class AbstractRequest extends CommonAbstractRequest
         switch ($this->getAcquirer()) {
             case 'ing':
                 return $base.'secure-ing.com/ideal/iDEALv3';
+            case 'abn':
+                $base = $this->getTestMode() ? '-test' : '';
+                return 'https://abnamro' . $base . '.ideal-payment.de/ideal/iDEALv3';
             case 'rabobank':
                 return $base.'rabobank.nl/ideal/iDEALv3';
             case 'bnpparibas':


### PR DESCRIPTION
Integrated ABN AMRO support, one of the major banks that use iDEAL. ABN uses a slightly different format for their test/live API URLs, but no changes had to be made to the rest of the application. Tested and working. 