### PR TITLE
Deutsche bank nederland support

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -24,7 +24,7 @@ class Gateway extends AbstractGateway
     public function getDefaultParameters()
     {
         return [
-            'acquirer'             => ['', 'simulator', 'ing', 'rabobank', 'abn'],
+            'acquirer'             => ['', 'simulator', 'ing', 'rabobank', 'abn', 'deutsche'],
             'merchantId'           => '',
             'publicKeyPath'        => '',
             'privateKeyPath'       => '',

--- a/src/Message/Request/AbstractRequest.php
+++ b/src/Message/Request/AbstractRequest.php
@@ -205,6 +205,8 @@ abstract class AbstractRequest extends CommonAbstractRequest
         switch ($this->getAcquirer()) {
             case 'ing':
                 return $base.'secure-ing.com/ideal/iDEALv3';
+            case 'deutsche':
+                return $base.'db.com/ideal/iDEALv3';
             case 'abn':
                 $base = $this->getTestMode() ? '-test' : '';
                 return 'https://abnamro' . $base . '.ideal-payment.de/ideal/iDEALv3';


### PR DESCRIPTION
Adds support for the ideal expert (v3) integration of Deutsche bank Nederland. endpoint works the same as all the other banks so only the URL needed to be added 😄.