### PR TITLE
fix: fetchIssuers fails with multiple countries

### DIFF
--- a/src/Message/Response/FetchIssuers.php
+++ b/src/Message/Response/FetchIssuers.php
@@ -25,7 +25,15 @@ class FetchIssuers extends AbstractResponse
     {
         if (isset($this->data['Directory'])) {
             $issuers = [];
-            foreach ($this->data['Directory']['Country']['Issuer'] as $issuer) {
+            if (is_array($this->data['Directory']['Country'])) {
+                // TODO: add option to filter by country
+                $issuerList = current(array_filter($this->data['Directory']['Country'], function($country) {
+                    return $country['countryNames'] === 'Nederland';
+                }))['Issuer'];
+            } else {
+                $issuerList = $this->data['Directory']['Country']['Issuer'];
+            }
+            foreach ($issuerList as $issuer) {
                 $id = (string) $issuer['issuerID'];
                 $issuers[$id] = (string) $issuer['issuerName'];
             }


### PR DESCRIPTION
Abn Amro now returns multiple countries, causing a failure when getting the issuers.

old directory response:
```
[
    {
        "Country": {
            "Issuer": [
                {
                    "issuerID": "INGBNL2A",
                    "issuerName": "Issuer Simulation V3 - ING"
                },
                {
                    "issuerID": "RABONL2U",
                    "issuerName": "Issuer Simulation V3 - RABO"
                }
            ],
            "countryNames": "Nederland"
        },
        "directoryDateTimestamp": "2014-08-04T08:40:45.000Z"
    }
]
```

new directory response:
```
[
    {
        "Country": [
            {
                "Issuer": {
                    "issuerID": "REVOLT21",
                    "issuerName": "Revolut"
                },
                "countryNames": "Lietuva"
            },
            {
                "Issuer": [
                    {
                        "issuerID": "ABNANL2A",
                        "issuerName": "ABN AMRO"
                    },
                    {
                        "issuerID": "ASNBNL21",
                        "issuerName": "ASN Bank"
                    }
                ],
                "countryNames": "Nederland"
            }
        ],
        "directoryDateTimestamp": "2020-12-02T03:29:51.000Z"
    }
]
```