### PR TITLE
fix: correct check to see if there are multiple countries

### DIFF
--- a/src/Message/Response/FetchIssuers.php
+++ b/src/Message/Response/FetchIssuers.php
@@ -25,13 +25,13 @@ class FetchIssuers extends AbstractResponse
     {
         if (isset($this->data['Directory'])) {
             $issuers = [];
-            if (is_array($this->data['Directory']['Country'])) {
+            if (isset($this->data['Directory']['Country']['Issuer'])) {
+                $issuerList = $this->data['Directory']['Country']['Issuer'];
+            } else {
                 // TODO: add option to filter by country
                 $issuerList = current(array_filter($this->data['Directory']['Country'], function($country) {
                     return $country['countryNames'] === 'Nederland';
                 }))['Issuer'];
-            } else {
-                $issuerList = $this->data['Directory']['Country']['Issuer'];
             }
             foreach ($issuerList as $issuer) {
                 $id = (string) $issuer['issuerID'];


### PR DESCRIPTION
@deniztezcan apologies, made a mistake in my last PR without proper testing 😞 

since the response is an associate array the is_array() call isn't enough, its better to just check if we can select the issuer(s) directly or if we have to dig deeper.